### PR TITLE
feat: deprecate PLD-Progression Grouper and forward to ChIC

### DIFF
--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -1,0 +1,73 @@
+# Deprecation & forwarding
+
+This repository is **deprecated**. Its functionality is superseded by the
+**Charité Imaging Classification (ChIC)**:
+
+- Live app: <https://halbritter-lab.github.io/ChIC/>
+- Repository: <https://github.com/halbritter-lab/ChIC>
+- Tracking issue: [halbritter-lab/ChIC#34](https://github.com/halbritter-lab/ChIC/issues/34)
+
+This document is the design record for the deprecation notice and the ordered
+checklist for taking it fully live.
+
+## Decisions
+
+- **Tone: "superseded, but still usable."** The banner states the tool is no
+  longer maintained and points to ChIC, but the app keeps working. The method
+  implemented here is published ([PMID:36246085](https://pubmed.ncbi.nlm.nih.gov/36246085/)),
+  so we do not block access to it. ChIC implements the newer Charité Imaging
+  Classification (classes A–E).
+- **No surprise auto-redirect.** Auto-redirecting users off a working page is a
+  known UX anti-pattern; the banner gives a clear, explicit "Open ChIC" link
+  instead.
+- **The notice is framework-independent.** It lives as static markup + inline
+  styles in [`index.html`](./index.html), *outside* `#app`. It therefore paints
+  immediately, requires no JavaScript, and remains visible even if the Vue app
+  fails to boot. Vue mounts into `#app`, a sibling node it never touches.
+- **The banner sits above the disclaimer modal** (`z-index: 2147483000` vs the
+  modal's `1001`) so the notice is never hidden behind the first-load gate.
+
+## What this PR changes (safe to merge; auto-deploys on push to `main`)
+
+- `index.html` — deprecation banner, updated `<title>`, and a `<meta name="description">` announcing the move.
+- `README.md` — a `> [!WARNING]` deprecation callout at the top; historical content preserved below.
+- `DEPRECATION.md` — this file.
+
+No application logic, component, or chart code is touched.
+
+## Activation checklist (repo-admin actions — do in this order)
+
+These cannot live in a code PR and must be done by a maintainer. **Order
+matters** because archiving makes the repository read-only.
+
+1. **Confirm timing.** Per [ChIC#34](https://github.com/halbritter-lab/ChIC/issues/34),
+   @CBrigl asked to hold off until the new classes are accepted/published.
+   Get a maintainer's go-ahead before marking this PR "Ready for review" and merging.
+2. **Merge this PR to `main`.** The `github pages` workflow rebuilds and
+   publishes to the `gh-pages` branch, so the banner goes live at
+   <https://halbritter-lab.github.io/pld-progression-grouper/>.
+3. **Verify** the banner and the "Open ChIC" link on the live site.
+4. **Update the repository description** to prefix `[DEPRECATED]`:
+   ```bash
+   gh repo edit halbritter-lab/pld-progression-grouper \
+     --description "[DEPRECATED] Superseded by ChIC (https://github.com/halbritter-lab/ChIC). PLD-Progression Grouper — visualize and analyze the progression of Polycystic Liver Disease (PLD)."
+   ```
+5. **Add deprecation topics:**
+   ```bash
+   gh repo edit halbritter-lab/pld-progression-grouper --add-topic deprecated --add-topic archived
+   ```
+6. **Archive the repository last** (makes it read-only; do this *after* the
+   README change is merged, since an archived repo's README can no longer be
+   edited). Unarchive if further edits are ever needed:
+   ```bash
+   gh repo archive halbritter-lab/pld-progression-grouper
+   ```
+7. **Close the loop:** update/close [ChIC#34](https://github.com/halbritter-lab/ChIC/issues/34).
+
+## Notes
+
+- GitHub Pages does not let us set HTTP `Sunset`/`Deprecation` response headers,
+  so deprecation is signalled in-page (banner, `<title>`, `<meta>`) and in the
+  README rather than via headers.
+- The `gh-pages` branch is build output; do not edit it by hand — merging to
+  `main` regenerates it.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+> [!WARNING]
+> **⚠️ This project is deprecated and no longer maintained.**
+>
+> It has been superseded by the **Charité Imaging Classification (ChIC)**.
+> 👉 **Use the new tool: https://halbritter-lab.github.io/ChIC/** &nbsp;([repository](https://github.com/halbritter-lab/ChIC))
+>
+> This repository stays online for reference. The method implemented here was published as [PMID:36246085](https://pubmed.ncbi.nlm.nih.gov/36246085/); ChIC implements the successor Charité Imaging Classification (classes A–E). See [halbritter-lab/ChIC#34](https://github.com/halbritter-lab/ChIC/issues/34) for context.
 
 <p align="center">
     <img src="public/logo.png" alt="PLD-Progression Grouper logo" width="192" height="192">

--- a/index.html
+++ b/index.html
@@ -5,12 +5,70 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="/favicon.ico">
-    <title>PLD Progression Grouper</title>
+    <title>[Deprecated] PLD Progression Grouper — moved to ChIC</title>
+    <meta name="description" content="Deprecated: the PLD-Progression Grouper is no longer maintained. It has been superseded by the Charité Imaging Classification (ChIC), available at https://halbritter-lab.github.io/ChIC/.">
+    <!--
+      Deprecation banner (see DEPRECATION.md).
+      Kept as static markup + inline styles in index.html — outside #app — so it
+      paints instantly, needs no JavaScript, and stays visible even if the Vue
+      app fails to boot. Vue mounts into #app and never touches this sibling node.
+    -->
+    <style>
+      #deprecation-banner {
+        position: sticky;
+        top: 0;
+        /* Above the disclaimer modal (z-index 1001) so the notice is never hidden. */
+        z-index: 2147483000;
+        box-sizing: border-box;
+        width: 100%;
+        margin: 0;
+        padding: 10px 16px;
+        background: #00bf7d;
+        color: #08261c;
+        border-bottom: 2px solid #08261c;
+        font-family: Arial, Helvetica, sans-serif;
+        font-size: 15px;
+        line-height: 1.45;
+        text-align: center;
+      }
+      #deprecation-banner .dep-text { vertical-align: middle; }
+      #deprecation-banner strong { font-weight: 700; }
+      #deprecation-banner a.dep-cta {
+        display: inline-block;
+        margin-left: 10px;
+        padding: 4px 12px;
+        background: #08261c;
+        color: #ffffff;
+        border-radius: 4px;
+        font-weight: 700;
+        text-decoration: none;
+        white-space: nowrap;
+        vertical-align: middle;
+      }
+      #deprecation-banner a.dep-cta:hover,
+      #deprecation-banner a.dep-cta:focus {
+        background: #0b3a2b;
+        outline: 2px solid #08261c;
+        outline-offset: 2px;
+      }
+      @media (max-width: 560px) {
+        #deprecation-banner { font-size: 13px; padding: 8px 10px; }
+        #deprecation-banner a.dep-cta { display: block; width: max-content; margin: 8px auto 2px; }
+      }
+    </style>
   </head>
   <body>
     <noscript>
       <strong>We're sorry but this app doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
+    <!-- Deprecation / forwarding notice — must remain the first child of <body>, a sibling of #app. -->
+    <div id="deprecation-banner" role="region" aria-label="Deprecation notice">
+      <span class="dep-text">
+        ⚠️ <strong>This tool is no longer maintained.</strong>
+        It has been superseded by the <strong>Charité Imaging Classification (ChIC)</strong>.
+      </span>
+      <a class="dep-cta" href="https://halbritter-lab.github.io/ChIC/" rel="noopener">Open ChIC →</a>
+    </div>
     <div id="app"></div>
     <script type="module" src="/src/main.js"></script>
     <!-- built files will be auto injected - This comment is no longer accurate for Vite -->


### PR DESCRIPTION
Resolves the "deprecation of previous tool & forwarding" request tracked in **halbritter-lab/ChIC#34**.

## What this does

Marks the **PLD-Progression Grouper** as deprecated and forwards users to its successor, the **Charité Imaging Classification (ChIC)** — <https://halbritter-lab.github.io/ChIC/>.

- **`index.html` — deprecation banner.** A static, framework-independent notice rendered *outside* `#app` with inline styles in `<head>`, so it paints immediately, needs no JavaScript, and stays visible even if the Vue app fails to boot (Vue mounts into `#app`, a sibling node it never touches). It's `position: sticky` with a very high `z-index`, so it sits above the first-load disclaimer modal. Also updates `<title>` and adds a `<meta name="description">` announcing the move.
- **`README.md`** — a `> [!WARNING]` deprecation callout at the top; all historical content preserved below.
- **`DEPRECATION.md`** — the design record and the ordered repo-admin activation checklist.

No application logic, component, or chart code is touched. The app stays fully usable — the method here is published ([PMID:36246085](https://pubmed.ncbi.nlm.nih.gov/36246085/)); we point users to ChIC without blocking access.

## Design choices

- **Tone: "superseded, but still usable"** (not a hard gate). Prominent CTA, no surprise auto-redirect — an explicit "Open ChIC" link instead (auto-redirecting off a working page is a known UX anti-pattern).
- **In-page signalling** (banner + `<title>` + `<meta>` + README). GitHub Pages can't set HTTP `Sunset`/`Deprecation` headers, so there's nothing header-based to add.

## Verification

Production build (`npm run build`) + headless screenshots at 1280×800 and 390×844:

- Banner paints instantly and **layers above** the disclaimer modal on both viewports (unmissable on first load).
- After dismissing the disclaimer, the app header sits flush **below** the banner — no overlap; the app is fully functional.
- Responsive: on narrow screens the text wraps and the CTA becomes a centered block button.

## ⚠️ Kept as a draft on purpose — merge = go-live

The old repo deploys to Pages on push to `main`, so **merging this publishes the banner**. Per ChIC#34, @CBrigl asked to *hold off until the new classes are accepted/published*. A maintainer should confirm timing before marking this "Ready for review" and merging.

The remaining repo-admin steps (repository description prefix, `deprecated`/`archived` topics, and archiving the repo **last**) can't live in a code PR — they're in [`DEPRECATION.md`](DEPRECATION.md) as a copy-paste `gh` checklist.
