### PR TITLE
ci: use ubuntu-latest runner so Pages can deploy

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:


### PR DESCRIPTION
The `github pages` workflow pinned the retired `ubuntu-20.04` runner, leaving deploys stuck queued. Switch to `ubuntu-latest` so the Pages deploy (and the deprecation banner from #60) publishes. Refs halbritter-lab/ChIC#34.